### PR TITLE
Added .sjs extension to filter

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function SweetjsFilter(inputTree, options) {
 SweetjsFilter.prototype = Object.create(Filter.prototype);
 SweetjsFilter.prototype.constructor = SweetjsFilter;
 
-SweetjsFilter.prototype.extensions = ['js'];
+SweetjsFilter.prototype.extensions = ['js', 'sjs'];
 SweetjsFilter.prototype.targetExtension = 'js';
 
 SweetjsFilter.prototype.processString = function (str) {


### PR DESCRIPTION
sweet.js officially supports either `.js` or the more formal `.sjs` extension.
##### References

https://github.com/mozilla/sweet.js/blob/08e4392b4e821ac1a4d19bc70ff792ad58336f32/src/sweet.js#L188
https://github.com/search?q=extension%3Asjs+macro&ref=searchresults&type=Code
